### PR TITLE
Initial Kubernetes Configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM phpipam/phpipam-www:latest
+
+RUN apk add curl jq bash php7-mcrypt && curl -L -O https://releases.hashicorp.com/vault/1.5.4/vault_1.5.4_linux_amd64.zip && \
+    unzip vault_1.5.4_linux_amd64.zip && rm vault_1.5.4_linux_amd64.zip && mv vault /usr/local/bin
+
+COPY . /phpipam/
+COPY entrypoint.sh /opt/entrypoint.sh
+
+ENTRYPOINT [ "/opt/entrypoint.sh" ]

--- a/devops/cron/Dockerfile
+++ b/devops/cron/Dockerfile
@@ -1,0 +1,9 @@
+FROM phpipam/phpipam-cron:latest
+
+RUN apk add curl jq bash && curl -L -O https://releases.hashicorp.com/vault/1.5.4/vault_1.5.4_linux_amd64.zip && \
+    unzip vault_1.5.4_linux_amd64.zip && rm vault_1.5.4_linux_amd64.zip && mv vault /usr/local/bin
+
+COPY . /phpipam/
+COPY devops/cron/cron-entrypoint.sh /opt/cron-entrypoint.sh
+
+ENTRYPOINT [ "/opt/cron-entrypoint.sh" ]

--- a/devops/cron/cron-entrypoint.sh
+++ b/devops/cron/cron-entrypoint.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+export VAULT_ADDR=${VAULT_ADDR:-"https://vault.umusic.net"}
+
+export VAULT_TOKEN=$(vault login -token-only -method=aws role=network-engineering-phpipam-reader)
+
+if [[ -z "$VAULT_TOKEN" ]]; then
+  echo "VAULT_TOKEN required" >&2
+  exit 1
+fi
+
+exportsecrets() {
+  VAULT_KV=$(echo $1 | awk -F'/' '{print $1}')
+  VAULT_KV_PATH=$(echo $1 | sed "s,$VAULT_KV/,,g")
+  VAULT_OUTPUT=`curl -s -H "X-Vault-Token: ${VAULT_TOKEN}" -X GET $VAULT_ADDR/v1/${VAULT_KV}/data/${VAULT_KV_PATH}`
+  if [[ "$(echo $VAULT_OUTPUT | jq -r '.errors')" != "null" ]]; then
+    echo Error from Vault $VAULT_ADDR/v1/${VAULT_KV}/data/${VAULT_KV_PATH}
+    echo $VAULT_OUTPUT
+    exit 1
+  fi
+  export $(echo $VAULT_OUTPUT | jq -r '.data.data | to_entries|map("\(.key)=\(.value|tostring)")|.[]')
+}
+
+exportsecrets $VAULT_KV_PATH
+
+/sbin/tini -- /bin/sh -c /start_crond

--- a/devops/k8s/cron/deploy-cron.yaml
+++ b/devops/k8s/cron/deploy-cron.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: phpipam-cron-v1
+  namespace: umg
+  labels:
+    app: phpipam-cron
+    version: v1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: phpipam-cron
+      version: v1
+  template:
+    metadata:
+      labels:
+        app: phpipam-cron
+        version: v1
+    spec:
+      serviceAccountName: phpipam
+      containers:
+      - name: phpipam
+        image: docker-registry.umusic.com/networking/phpipam-cron:v1.4.2-umg-1.0
+        resources:
+          limits:
+            memory: 1024Mi
+            cpu: 1000m
+          requests:
+            memory: 1024Mi
+            cpu: 1000m
+        env:
+        - name: VAULT_KV_PATH
+          value: VAULT_KV_PATH
+        securityContext:
+          capabilities:
+            add: ["IPC_LOCK"]
+      imagePullSecrets:
+      - name: regcred

--- a/devops/k8s/deploy.yaml
+++ b/devops/k8s/deploy.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: phpipam-v1
+  namespace: umg
+  labels:
+    app: phpipam
+    version: v1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: phpipam
+      version: v1
+  template:
+    metadata:
+      labels:
+        app: phpipam
+        version: v1
+    spec:
+      serviceAccountName: phpipam
+      containers:
+      - name: phpipam
+        image: docker-registry.umusic.com/networking/phpipam:v1.4.2-umg-1.0
+        resources:
+          limits:
+            memory: 1024Mi
+            cpu: 1000m
+          requests:
+            memory: 1024Mi
+            cpu: 1000m
+        env:
+        - name: VAULT_KV_PATH
+          value: VAULT_KV_PATH
+        ports:
+        - containerPort: 80
+        - containerPort: 443
+        securityContext:
+          capabilities:
+            add: ["IPC_LOCK"]
+      imagePullSecrets:
+      - name: regcred

--- a/devops/k8s/service.yaml
+++ b/devops/k8s/service.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: phpipam
+  namespace: phpipam-dev
+  labels:
+    app: phpipam
+spec:
+  type: ClusterIP
+  selector:
+    app: phpipam
+  ports:
+    - protocol: TCP
+      port: 80
+      name: http
+      targetPort: 80
+    - protocol: TCP
+      port: 443
+      name: https
+      targetPort: 443

--- a/devops/k8s/serviceaccounts/phpipam-dev.yaml
+++ b/devops/k8s/serviceaccounts/phpipam-dev.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: phpipam
+  namespace: phpipam-dev
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::029216723584:role/aws42_phpipam
+  labels:
+    app: phpipam

--- a/devops/tekton/trigger-cron.json
+++ b/devops/tekton/trigger-cron.json
@@ -4,7 +4,7 @@
         "Pipeline": "poc-vault"
     },
     "Git": {
-        "Ref": "refs/heads/devops/k8s",
+        "Ref": "refs/heads/master",
         "Revision": "",
         "URL": "https://github.com/umg/phpipam.git"
     },

--- a/devops/tekton/trigger-cron.json
+++ b/devops/tekton/trigger-cron.json
@@ -1,0 +1,28 @@
+{
+    "API": {
+        "APIVersion": "v1",
+        "Pipeline": "poc-vault"
+    },
+    "Git": {
+        "Ref": "refs/heads/devops/k8s",
+        "Revision": "",
+        "URL": "https://github.com/umg/phpipam.git"
+    },
+    "Image": {
+        "URL": "docker-registry.umusic.com/networking/phpipam-cron",
+        "Tag": "v1.4.2-umg-1.0.1",
+        "Dockerfile": "devops/cron/Dockerfile",
+        "Context": ""
+    },
+    "K8S": {
+        "YamlPath": "devops/k8s/cron/deploy-cron.yaml",
+        "YamlDir": "",
+        "Namespace": "phpipam-dev",
+        "ClusterName": "aws42-istio-networking"
+    },
+    "Config": {
+        "VaultKVPath": "network-engineering/phpipam/dev",
+        "UserData": "",
+        "EventID": ""
+    }
+}

--- a/devops/tekton/trigger.json
+++ b/devops/tekton/trigger.json
@@ -4,7 +4,7 @@
         "Pipeline": "poc-vault"
     },
     "Git": {
-        "Ref": "refs/heads/devops/k8s",
+        "Ref": "refs/heads/master",
         "Revision": "",
         "URL": "https://github.com/umg/phpipam.git"
     },

--- a/devops/tekton/trigger.json
+++ b/devops/tekton/trigger.json
@@ -1,0 +1,28 @@
+{
+    "API": {
+        "APIVersion": "v1",
+        "Pipeline": "poc-vault"
+    },
+    "Git": {
+        "Ref": "refs/heads/devops/k8s",
+        "Revision": "",
+        "URL": "https://github.com/umg/phpipam.git"
+    },
+    "Image": {
+        "URL": "docker-registry.umusic.com/networking/phpipam",
+        "Tag": "v1.4.2-umg-1.0.9",
+        "Dockerfile": "Dockerfile",
+        "Context": ""
+    },
+    "K8S": {
+        "YamlPath": "devops/app.yaml",
+        "YamlDir": "devops/k8s",
+        "Namespace": "phpipam-dev",
+        "ClusterName": "aws42-istio-networking"
+    },
+    "Config": {
+        "VaultKVPath": "network-engineering/phpipam/dev",
+        "UserData": "",
+        "EventID": ""
+    }
+}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+export VAULT_ADDR=${VAULT_ADDR:-"https://vault.umusic.net"}
+
+export VAULT_TOKEN=$(vault login -token-only -method=aws role=network-engineering-phpipam-reader)
+
+if [[ -z "$VAULT_TOKEN" ]]; then
+  echo "VAULT_TOKEN required" >&2
+  exit 1
+fi
+
+exportsecrets() {
+  VAULT_KV=$(echo $1 | awk -F'/' '{print $1}')
+  VAULT_KV_PATH=$(echo $1 | sed "s,$VAULT_KV/,,g")
+  VAULT_OUTPUT=`curl -s -H "X-Vault-Token: ${VAULT_TOKEN}" -X GET $VAULT_ADDR/v1/${VAULT_KV}/data/${VAULT_KV_PATH}`
+  if [[ "$(echo $VAULT_OUTPUT | jq -r '.errors')" != "null" ]]; then
+    echo Error from Vault $VAULT_ADDR/v1/${VAULT_KV}/data/${VAULT_KV_PATH}
+    echo $VAULT_OUTPUT
+    exit 1
+  fi
+  export $(echo $VAULT_OUTPUT | jq -r '.data.data | to_entries|map("\(.key)=\(.value|tostring)")|.[]')
+}
+
+exportsecrets $VAULT_KV_PATH
+
+ln -s config.docker.php config.php
+
+/sbin/tini -- /bin/sh -c /start_apache2


### PR DESCRIPTION
Adds `devops` directory which includes base Kubernetes configurations.

Additionally, adds `Dockerfile` which builds on top of `phpipam` upstream base image to include `vault` authentication and exports vault secrets to the environment before starting `entrypoint`.

These configurations make some assumptions about the application scale and configuration. Currently it only runs a single replica (no HA) and over provisions CPU and RAM.

Once development stabilizes we need to profile the resource usage to rightsize the pods.

Some things to note about configuration:

- Secrets / config values are all stored in Vault under `network-engineering/phpipam/$ENVIRONMENT` path. These are exported to the environment at container start up.
- Authentication to Vault is done with AWS IAM role / Vault AWS auth method.
- Build / deploy is done through Tekton (https://tekton.devops.umgapps.com) and can be triggered with the Tekton Triggers API endpoint (https://tektontrigger.devops.umgapps.com/v1/).
    - Example Tekton Triggers JSON payloads reside in `devops/tekton`.
    - Key values to pay attention to:
        - `Git.Ref`: the branch / tag / commit to build / deploy
        - `Git.URL`: the git repo to build / deploy
        - `Image.Tag`: the container tag to build / deploy. When releasing a new version, this must be updated.
        - `K8S.ClusterName` & `K8S.Namespace`: the cluster and namespace to deploy into. Default configured for DEV.
        - `Config.VaultKVPath`: the vault KV path to pull secrets from at runtime. 
     
For initial dev POC, we are using the default GitHub webhooks configuration. This configuration is intended for quick POC to a single environment but is not intended for full multi-environment CI/CD and makes broad assumptions:

- Will only respect `devops/tekton/trigger.json`.
    - This does not take into consideration the separate `devops/tekton/trigger-cron.json` configuration file.
        - For now, this must be manually `POST`ed to the tekton trigger `/poc-vault` endpoint.
- Will only build / deploy from the branch / git ref hardcoded / defined in `devops/tekton/trigger.json` `Git.Ref`, and will only build / deploy the `Image.Tag` that is hardcoded.
    - To track a different branch, or to build a new version, this must be manually updated in the `trigger.json` file before committing / pushing.

For a more scalable / automated CI/CD solution, either client-side scripts must be used to configure and `POST` the `trigger.json` file(s), or dynamic configuration should be shifted to a `GitHub Actions` runner where the dynamic configuration scripts can run on each check-in.

For example (pseudo-code):

````
if GIT_BRANCH == "master" {
    build_deploy -app "phpipam" -env "prod" > updated-trigger.json
    build_deploy -app "phpipam-cron" -env "prod" > updated-trigger-cron.json
} else {
    build_deploy -app "phpipam" -env "dev" > updated-trigger.json
    build_deploy -app "phpipam-cron" -env "dev" > updated-trigger-cron.json
}

post_tekton_trigger updated-trigger.json
post_tekton_trigger updated-trigger-cron.json
````

Once the PHP IPAM team is ready, DevOps can set up the PROD environment (RDS, cluster environment, vault paths).

Once PROD is set up, we can discuss desire / requirements / next steps for fully automated CI/CD pipelines.