### PR TITLE
Refactor: API controller cleanup

### DIFF
--- a/api/controllers/Addresses.php
+++ b/api/controllers/Addresses.php
@@ -7,79 +7,6 @@
  */
 class Addresses_controller extends Common_api_functions  {
 
-
-	/**
-	 * Input parameters
-	 *
-	 * @var mixed
-	 * @access public
-	 */
-	public $_params;
-
-	/**
-	 * Custom address fields
-	 *
-	 * @var mixed
-	 * @access public
-	 */
-	public $custom_fields;
-
-	/**
-	 * Database object
-	 *
-	 * @var mixed
-	 * @access protected
-	 */
-	protected $Database;
-
-	/**
-	 * Sections object
-	 *
-	 * @var mixed
-	 * @access protected
-	 */
-	protected $Sections;
-
-	/**
-	 * Response handler
-	 *
-	 * @var mixed
-	 * @access protected
-	 */
-	protected $Response;
-
-	/**
-	 * Tools object from master Tools class
-	 *
-	 * @var mixed
-	 * @access protected
-	 */
-	protected $Tools;
-
-	/**
-	 * Subnets object from master Subnets class
-	 *
-	 * @var mixed
-	 * @access protected
-	 */
-	public $Subnets;
-
-	/**
-	 * Addresses object from master Addresses class
-	 *
-	 * @var mixed
-	 * @access public
-	 */
-	public $Addresses;
-
-	/**
-	 * Admin class form master Admin class
-	 *
-	 * @var mixed
-	 * @access public
-	 */
-	public $Admin;
-
 	/**
 	 * Saves details of currnt subnet
 	 *
@@ -347,20 +274,6 @@ class Addresses_controller extends Common_api_functions  {
             else                                        { return array("code"=>200, "data"=>$this->prepare_result ($result, $this->_params->controller, false, false));}
 		// false
 		} else											{  $this->Response->throw_exception(400, "Invalid Id"); }
-	}
-
-
-
-
-
-	/**
-	 * HEAD, no response
-	 *
-	 * @access public
-	 * @return void
-	 */
-	public function HEAD () {
-		return $this->GET ();
 	}
 
 

--- a/api/controllers/Circuits.php
+++ b/api/controllers/Circuits.php
@@ -7,23 +7,6 @@
  */
 class Circuits_controller extends Common_api_functions {
 
-
-	/**
-	 * _params provided
-	 *
-	 * @var mixed
-	 * @access public
-	 */
-	public $_params;
-
-	/**
-	 * custom_fields
-	 *
-	 * @var mixed
-	 * @access protected
-	 */
-	public $custom_fields;
-
 	/**
 	 * Request type - circuits or circuitProviders
 	 *
@@ -37,30 +20,6 @@ class Circuits_controller extends Common_api_functions {
 	 * @var string
 	 */
 	protected $type_text = "circuit";
-
-	/**
-	 * Database object
-	 *
-	 * @var mixed
-	 * @access protected
-	 */
-	protected $Database;
-
-	/**
-	 * Master Tools object
-	 *
-	 * @var mixed
-	 * @access protected
-	 */
-	protected $Tools;
-
-	/**
-	 * Master Admin object
-	 *
-	 * @var mixed
-	 * @access protected
-	 */
-	protected $Admin;
 
 
 	/**
@@ -211,19 +170,6 @@ class Circuits_controller extends Common_api_functions {
 			if($result==NULL)						{ $this->Response->throw_exception(200, "{$this->type_text} not found"); }
 			else									{ return array("code"=>200, "data"=>$this->prepare_result ($result, null, true, true)); }
 		}
-	}
-
-
-
-
-	/**
-	 * HEAD, no response
-	 *
-	 * @access public
-	 * @return void
-	 */
-	public function HEAD () {
-		return $this->GET ();
 	}
 
 

--- a/api/controllers/Common.php
+++ b/api/controllers/Common.php
@@ -95,6 +95,14 @@ class Common_api_functions {
 	protected $keys;
 
 	/**
+	 * Database object
+	 *
+	 * @var mixed
+	 * @access protected
+	 */
+	protected $Database;
+
+	/**
 	 * Master Tools class
 	 *
 	 * @var mixed
@@ -119,12 +127,36 @@ class Common_api_functions {
 	protected $Subnets;
 
 	/**
+	 * Master Addresses object
+	 *
+	 * @var mixed
+	 * @access protected
+	 */
+	protected $Addresses;
+
+	/**
+	 * Master Sections object
+	 *
+	 * @var mixed
+	 * @access protected
+	 */
+	protected $Sections;
+
+	/**
 	 * Master user class
 	 *
 	 * @var mixed
 	 * @access protected
 	 */
 	protected $User;
+
+	/**
+	 * Master Admin object
+	 *
+	 * @var mixed
+	 * @access protected
+	 */
+	protected $Admin;
 
 	/**
 	 * App object - will be passed by index.php
@@ -135,6 +167,48 @@ class Common_api_functions {
 	public $app = false;
 
 
+
+
+	/**
+	 * Provide default REQUEST_METHODs
+	 *
+	 */
+
+	private function NOT_IMPLEMENTED() {
+		return array("code"=>501, "message"=>"Method not implemented");
+	}
+
+	public function OPTIONS () {
+		return $this->NOT_IMPLEMENTED ();
+	}
+
+	public function GET () {
+		return $this->NOT_IMPLEMENTED ();
+	}
+
+	public function POST () {
+		return $this->NOT_IMPLEMENTED ();
+	}
+
+	public function PATCH () {
+		return $this->NOT_IMPLEMENTED ();
+	}
+
+	public function DELETE () {
+		return $this->NOT_IMPLEMENTED ();
+	}
+
+	/* Alias HEAD to GET */
+
+	public function HEAD () {
+		return $this->GET ();
+	}
+
+	/* Alias PUT to PATCH */
+
+	public function PUT () {
+		return $this->PATCH ();
+	}
 
 
 

--- a/api/controllers/Devices.php
+++ b/api/controllers/Devices.php
@@ -8,48 +8,6 @@
 class Devices_controller extends Common_api_functions {
 
     /**
-     * _params provided.
-     *
-     * @var mixed
-     */
-    public $_params;
-
-    /**
-     * Database object.
-     *
-     * @var mixed
-     */
-    protected $Database;
-
-    /**
-     * Response.
-     *
-     * @var mixed
-     */
-    protected $Response;
-
-    /**
-     * Master Tools object.
-     *
-     * @var mixed
-     */
-    protected $Tools;
-
-    /**
-     * Main Admin class.
-     *
-     * @var mixed
-     */
-    protected $Admin;
-
-    /**
-     * Main Subnets class.
-     *
-     * @var mixed
-     */
-    protected $Subnets;
-
-    /**
      * Default fields to search.
      *
      * @var mixed
@@ -209,17 +167,6 @@ class Devices_controller extends Common_api_functions {
                 else                        { return array('code'=>200, 'data'=>$this->prepare_result($result, 'devices', true, false)); }
             }
         }
-    }
-
-
-
-
-
-    /**
-     * HEAD, no response.
-     */
-    public function HEAD () {
-        return $this->GET ();
     }
 
 

--- a/api/controllers/Folders.php
+++ b/api/controllers/Folders.php
@@ -1,103 +1,10 @@
 <?php
 
 /**
- *	phpIPAM API class to work with folders
- *
- *	just an alias for subnets
- *
+ *	just an alias for Subnets
  */
-class Folders_controller extends Common_api_functions {
 
-    /**
-     * Subnets_controller
-     *
-     * @var mixed
-     * @access protected
-     */
-    protected $Subnets_controller;
+require("Subnets.php");
 
-	/**
-	 * __construct function
-	 *
-	 * @access public
-	 * @param class $Database
-	 * @param class $Tools
-	 * @param mixed $params		// post/get values
-	 * @param mixed $Response
-	 */
-	public function __construct($Database, $Tools, $params, $Response) {
-		// include
-		require("Subnets.php");
-		// subnets
-		$this->Subnets_controller = new Subnets_controller ($Database, $Tools, $params, $Response);
-	}
-
-
-
-
-	/**
-	 * Options
-	 *
-	 * @access public
-	 * @return void
-	 */
-	public function OPTIONS () {
-		return $this->Subnets_controller->OPTIONS ();
-	}
-
-	/**
-	 * HEAD, no response
-	 *
-	 * @access public
-	 * @return void
-	 */
-	public function HEAD () {
-		return $this->Subnets_controller->GET ();
-	}
-
-
-	/**
-	 * Creates new folder
-	 *
-	 * @access public
-	 * @return void
-	 */
-	public function POST () {
-		return $this->Subnets_controller->POST ();
-	}
-
-
-	/**
-	 * Read folder functions
-	 *
-	 * @access public
-	 * @return void
-	 */
-	public function GET () {
-		return $this->Subnets_controller->GET ();
-	}
-
-
-	/**
-	 * Updates existing subnet
-	 *
-	 * @access public
-	 * @return void
-	 */
-	public function PATCH () {
-		return $this->Subnets_controller->PATCH ();
-	}
-
-
-	/**
-	 * Deletes existing subnet along with and addresses
-	 *
-	 * @access public
-	 * @return void
-	 */
-	public function DELETE () {
-		return $this->Subnets_controller->DELETE ();
-	}
+class Folders_controller extends Subnets_controller {
 }
-
-?>

--- a/api/controllers/L2domains.php
+++ b/api/controllers/L2domains.php
@@ -8,56 +8,6 @@
 
 class L2domains_controller extends Common_api_functions {
 
-
-	/**
-	 * _params provided
-	 *
-	 * @var mixed
-	 * @access public
-	 */
-	public $_params;
-
-	/**
-	 * custom_fields
-	 *
-	 * @var mixed
-	 * @access protected
-	 */
-	public $custom_fields;
-
-	/**
-	 * Database object
-	 *
-	 * @var mixed
-	 * @access protected
-	 */
-	protected $Database;
-
-	/**
-	 * master Sections object
-	 *
-	 * @var mixed
-	 * @access protected
-	 */
-	protected $Sections;
-
-	/**
-	 * Master Tools object
-	 *
-	 * @var mixed
-	 * @access protected
-	 */
-	protected $Tools;
-
-	/**
-	 * Master Admin object
-	 *
-	 * @var mixed
-	 * @access protected
-	 */
-	protected $Admin;
-
-
 	/**
 	 * __construct function
 	 *
@@ -160,19 +110,6 @@ class L2domains_controller extends Common_api_functions {
 			}
 
 		}
-	}
-
-
-
-
-	/**
-	 * HEAD, no response
-	 *
-	 * @access public
-	 * @return void
-	 */
-	public function HEAD () {
-		return $this->GET ();
 	}
 
 
@@ -324,5 +261,3 @@ class L2domains_controller extends Common_api_functions {
 
 	}
 }
-
-?>

--- a/api/controllers/Prefix.php
+++ b/api/controllers/Prefix.php
@@ -33,22 +33,6 @@
 class Prefix_controller extends Common_api_functions {
 
     /**
-     * _params provided
-     *
-     * @var mixed
-     * @access public
-     */
-    public $_params;
-
-    /**
-     * custom_fields
-     *
-     * @var mixed
-     * @access protected
-     */
-    public $custom_fields;
-
-    /**
      * Custom field selector
      *
      *  This will be used to search for subnets that have {$custom_field_name = customer_type}
@@ -240,22 +224,6 @@ class Prefix_controller extends Common_api_functions {
     private $master_subnet = false;
 
     /**
-     * Database object
-     *
-     * @var mixed
-     * @access protected
-     */
-    protected $Database;
-
-    /**
-     *  Response handler
-     *
-     * @var mixed
-     * @access protected
-     */
-    protected $Response;
-
-    /**
      * Subnets controller
      *
      * @var mixed
@@ -270,38 +238,6 @@ class Prefix_controller extends Common_api_functions {
      * @access protected
      */
     protected $Addresses_controller;
-
-    /**
-     * Master Subnets object
-     *
-     * @var mixed
-     * @access protected
-     */
-    protected $Subnets;
-
-    /**
-     * Master Addresses object
-     *
-     * @var mixed
-     * @access protected
-     */
-    protected $Addresses;
-
-    /**
-     * Master Sections object
-     *
-     * @var mixed
-     * @access protected
-     */
-    protected $Sections;
-
-    /**
-     * Master Tools object
-     *
-     * @var mixed
-     * @access protected
-     */
-    protected $Tools;
 
 
     /**
@@ -521,19 +457,6 @@ class Prefix_controller extends Common_api_functions {
 
 
 
-    /**
-     * HEAD, no response
-     *
-     * @access public
-     * @return void
-     */
-    public function HEAD () {
-        return $this->GET ();
-    }
-
-
-
-
 
     /**
      * Creates new prefix or address, based on input parameters
@@ -647,33 +570,6 @@ class Prefix_controller extends Common_api_functions {
     		//set result
             return array("code"=>201, "message"=>"Address created", "id"=>$this->Addresses->lastId, "subnetId"=>$this->master_subnet->id, "data"=>$this->Addresses->transform_address ($this->_params->ip_addr, "dotted"), "location"=>"/api/".$this->_params->app_id."/addresses/".$this->Addresses->lastId."/");
 		}
-    }
-
-
-
-
-    /**
-     * PATCH method
-     *
-     *  Not needed
-     *
-     * @access public
-     * @return void
-     */
-    public function PATCH () {
-        $this->Response->throw_exception(501, "Method not imeplemented");
-    }
-
-    /**
-     * DELETE method
-     *
-     *  Not needed
-     *
-     * @access public
-     * @return void
-     */
-    public function DELETE () {
-        $this->Response->throw_exception(501, "Method not imeplemented");
     }
 
 
@@ -960,5 +856,3 @@ class Prefix_controller extends Common_api_functions {
         }
     }
 }
-
-?>

--- a/api/controllers/Responses.php
+++ b/api/controllers/Responses.php
@@ -26,9 +26,6 @@ class Responses extends Result {
 	public $time = false;
 
 
-
-
-
 	/**
 	 * __construct function
 	 *

--- a/api/controllers/Sections.php
+++ b/api/controllers/Sections.php
@@ -7,64 +7,6 @@
  */
 class Sections_controller extends Common_api_functions {
 
-
-	/**
-	 * _params provided
-	 *
-	 * @var mixed
-	 * @access public
-	 */
-	public $_params;
-
-	/**
-	 * custom_fields
-	 *
-	 * @var mixed
-	 * @access protected
-	 */
-	public $custom_fields;
-
-	/**
-	 * Database object
-	 *
-	 * @var mixed
-	 * @access protected
-	 */
-	protected $Database;
-
-	/**
-	 *  Response handler
-	 *
-	 * @var mixed
-	 * @access protected
-	 */
-	protected $Response;
-
-	/**
-	 * Master Subnets object
-	 *
-	 * @var mixed
-	 * @access protected
-	 */
-	protected $Subnets;
-
-	/**
-	 * Master Sections object
-	 *
-	 * @var mixed
-	 * @access protected
-	 */
-	protected $Sections;
-
-	/**
-	 * Master Tools object
-	 *
-	 * @var mixed
-	 * @access protected
-	 */
-	protected $Tools;
-
-
 	/**
 	 * __construct function
 	 *
@@ -212,19 +154,6 @@ class Sections_controller extends Common_api_functions {
 
 
 
-	/**
-	 * HEAD, no response
-	 *
-	 * @access public
-	 * @return void
-	 */
-	public function HEAD () {
-		return $this->GET ();
-	}
-
-
-
-
 
 	/**
 	 * Creates new section
@@ -359,5 +288,3 @@ class Sections_controller extends Common_api_functions {
         return $subnet_usage;
 	 }
 }
-
-?>

--- a/api/controllers/Subnets.php
+++ b/api/controllers/Subnets.php
@@ -8,68 +8,12 @@
 class Subnets_controller extends Common_api_functions {
 
 	/**
-	 * _params provided
-	 *
-	 * @var mixed
-	 * @access public
-	 */
-	public $_params;
-
-	/**
-	 * custom_fields
-	 *
-	 * @var mixed
-	 * @access protected
-	 */
-	public $custom_fields;
-
-	/**
 	 * settings
 	 *
 	 * @var mixed
 	 * @access protected
 	 */
 	protected $settings;
-
-	/**
-	 * Database object
-	 *
-	 * @var mixed
-	 * @access protected
-	 */
-	protected $Database;
-
-	/**
-	 * Response handler
-	 *
-	 * @var mixed
-	 * @access protected
-	 */
-	protected $Response;
-
-	/**
-	 * Master Subnets object
-	 *
-	 * @var mixed
-	 * @access protected
-	 */
-	protected $Subnets;
-
-	/**
-	 * Master  Addresses object
-	 *
-	 * @var mixed
-	 * @access protected
-	 */
-	protected $Addresses;
-
-	/**
-	 * Master Tools object
-	 *
-	 * @var mixed
-	 * @access protected
-	 */
-	protected $Tools;
 
 
 	/**
@@ -308,20 +252,6 @@ class Subnets_controller extends Common_api_functions {
 		}
 		// false
 		else 											{ $this->Response->throw_exception(404, 'Invalid Id'); }
-	}
-
-
-
-
-
-	/**
-	 * HEAD, no response
-	 *
-	 * @access public
-	 * @return array
-	 */
-	public function HEAD () {
-		return $this->GET ();
 	}
 
 

--- a/api/controllers/Tools.php
+++ b/api/controllers/Tools.php
@@ -8,15 +8,6 @@
 
 class Tools_controller extends Common_api_functions {
 
-
-	/**
-	 * _params provided
-	 *
-	 * @var mixed
-	 * @access public
-	 */
-	public $_params;
-
 	/**
 	 * subcontrollers
 	 *
@@ -41,45 +32,6 @@ class Tools_controller extends Common_api_functions {
 	 */
 	protected $identifiers;
 
-	/**
-	 * Database object
-	 *
-	 * @var mixed
-	 * @access protected
-	 */
-	protected $Database;
-
-	/**
-	 * Response
-	 *
-	 * @var mixed
-	 * @access protected
-	 */
-	protected $Response;
-
-	/**
-	 * Master Tools object
-	 *
-	 * @var mixed
-	 * @access protected
-	 */
-	protected $Tools;
-
-	/**
-	 * Main Admin class
-	 *
-	 * @var mixed
-	 * @access protected
-	 */
-	protected $Admin;
-
-	/**
-	 * Main Subnets class
-	 *
-	 * @var mixed
-	 * @access protected
-	 */
-	protected $Subnets;
 
 	/**
 	 * __construct function
@@ -410,21 +362,6 @@ class Tools_controller extends Common_api_functions {
 
 		//set result
 		return array("code"=>201, "data"=>$table_name." object created", "id"=>$this->Admin->lastId, "location"=>"/api/".$this->_params->app_id."/tools/".$table_name."/".$this->Admin->lastId."/");
-	}
-
-
-
-
-
-
-	/**
-	 * HEAD, no response
-	 *
-	 * @access public
-	 * @return void
-	 */
-	public function HEAD () {
-		return $this->GET ();
 	}
 
 

--- a/api/controllers/User.php
+++ b/api/controllers/User.php
@@ -8,7 +8,6 @@
 
 class User_controller extends Common_api_functions {
 
-
 	/**
 	 * users token
 	 *
@@ -58,47 +57,6 @@ class User_controller extends Common_api_functions {
 	 * @access private
 	 */
 	private $block_ip = true;
-
-	/**
-	 * Database object
-	 *
-	 * @var mixed
-	 * @access protected
-	 */
-	protected $Database;
-
-	/**
-	 * Master Tools object
-	 *
-	 * @var mixed
-	 * @access protected
-	 */
-	protected $Tools;
-
-	/**
-	 * Master Admin object
-	 *
-	 * @var mixed
-	 * @access protected
-	 */
-	protected $Admin;
-
-	/**
-	 * Master User object
-	 *
-	 * @var mixed
-	 * @access protected
-	 */
-	protected $User;
-
-	/**
-	 * requested parameters
-	 *
-	 * @var mixed
-	 * @access public
-	 */
-	public $_params;
-
 
 
 	/**

--- a/api/controllers/Vlan.php
+++ b/api/controllers/Vlan.php
@@ -1,103 +1,10 @@
 <?php
 
 /**
- *	phpIPAM API class to work with folders
- *
- *	just an alias for subnets
- *
+ *	just an alias for Vlans
  */
-class Vlan_controller extends Common_api_functions {
 
-    /**
-     * Vlans_controller
-     *
-     * @var mixed
-     * @access protected
-     */
-    protected $Vlans_controller;
+require("Vlans.php");
 
-	/**
-	 * __construct function
-	 *
-	 * @access public
-	 * @param class $Database
-	 * @param class $Tools
-	 * @param mixed $params		// post/get values
-	 * @param mixed $Response
-	 */
-	public function __construct($Database, $Tools, $params, $Response) {
-		// include
-		require("Vlans.php");
-		// subnets
-		$this->Vlans_controller = new Vlans_controller ($Database, $Tools, $params, $Response);
-	}
-
-
-
-
-	/**
-	 * Options
-	 *
-	 * @access public
-	 * @return void
-	 */
-	public function OPTIONS () {
-		return $this->Vlans_controller->OPTIONS ();
-	}
-
-	/**
-	 * HEAD, no response
-	 *
-	 * @access public
-	 * @return void
-	 */
-	public function HEAD () {
-		return $this->Vlans_controller->GET ();
-	}
-
-
-	/**
-	 * Creates new folder
-	 *
-	 * @access public
-	 * @return void
-	 */
-	public function POST () {
-		return $this->Vlans_controller->POST ();
-	}
-
-
-	/**
-	 * Read folder functions
-	 *
-	 * @access public
-	 * @return void
-	 */
-	public function GET () {
-		return $this->Vlans_controller->GET ();
-	}
-
-
-	/**
-	 * Updates existing subnet
-	 *
-	 * @access public
-	 * @return void
-	 */
-	public function PATCH () {
-		return $this->Vlans_controller->PATCH ();
-	}
-
-
-	/**
-	 * Deletes existing subnet along with and addresses
-	 *
-	 * @access public
-	 * @return void
-	 */
-	public function DELETE () {
-		return $this->Vlans_controller->DELETE ();
-	}
+class Vlan_controller extends Vlans_controller {
 }
-
-?>

--- a/api/controllers/Vlans.php
+++ b/api/controllers/Vlans.php
@@ -8,23 +8,6 @@
 
 class Vlans_controller extends Common_api_functions {
 
-
-	/**
-	 * _params provided
-	 *
-	 * @var mixed
-	 * @access public
-	 */
-	public $_params;
-
-	/**
-	 * custom_fields
-	 *
-	 * @var mixed
-	 * @access protected
-	 */
-	public $custom_fields;
-
 	/**
 	 * settings
 	 *
@@ -32,38 +15,6 @@ class Vlans_controller extends Common_api_functions {
 	 * @access protected
 	 */
 	protected $settings;
-
-	/**
-	 * Database object
-	 *
-	 * @var mixed
-	 * @access protected
-	 */
-	protected $Database;
-
-	/**
-	 * Master Sections object
-	 *
-	 * @var mixed
-	 * @access protected
-	 */
-	protected $Sections;
-
-	/**
-	 * Master Tools object
-	 *
-	 * @var mixed
-	 * @access protected
-	 */
-	protected $Tools;
-
-	/**
-	 * Master Admin object
-	 *
-	 * @var mixed
-	 * @access protected
-	 */
-	protected $Admin;
 
 
 	/**
@@ -196,19 +147,6 @@ class Vlans_controller extends Common_api_functions {
 			if($result==NULL)						{ $this->Response->throw_exception(200, "Vlan not found"); }
 			else									{ return array("code"=>200, "data"=>$this->prepare_result ($result, null, true, true)); }
 		}
-	}
-
-
-
-
-	/**
-	 * HEAD, no response
-	 *
-	 * @access public
-	 * @return void
-	 */
-	public function HEAD () {
-		return $this->GET ();
 	}
 
 
@@ -394,5 +332,3 @@ class Vlans_controller extends Common_api_functions {
     	return $this->Subnets->find_gateway ($subnetId);
 	}
 }
-
-?>

--- a/api/controllers/Vrf.php
+++ b/api/controllers/Vrf.php
@@ -1,101 +1,10 @@
 <?php
 
 /**
- *	phpIPAM API class to work with folders
- *
- *	just an alias for subnets
- *
+ *	just an alias for Vrfs
  */
-class Vrf_controller extends Common_api_functions {
 
-    /**
-     * vrf_controller
-     *
-     * @var mixed
-     * @access protected
-     */
-    protected $Vrfs_controller;
+require("Vrfs.php");
 
-	/**
-	 * __construct function
-	 *
-	 * @access public
-	 * @param class $Database
-	 * @param class $Tools
-	 * @param mixed $params		// post/get values
-	 * @param mixed $Response
-	 */
-	public function __construct($Database, $Tools, $params, $Response) {
-		// include
-		require("Vrfs.php");
-		// subnets
-		$this->Vrfs_controller = new Vrfs_controller ($Database, $Tools, $params, $Response);
-	}
-
-
-
-
-	/**
-	 * Options
-	 *
-	 * @access public
-	 * @return void
-	 */
-	public function OPTIONS () {
-		return $this->Vrfs_controller->OPTIONS ();
-	}
-
-	/**
-	 * HEAD, no response
-	 *
-	 * @access public
-	 * @return void
-	 */
-	public function HEAD () {
-		return $this->Vrfs_controller->GET ();
-	}
-
-
-	/**
-	 * Creates new folder
-	 *
-	 * @access public
-	 * @return void
-	 */
-	public function POST () {
-		return $this->Vrfs_controller->POST ();
-	}
-
-
-	/**
-	 * Read folder functions
-	 *
-	 * @access public
-	 * @return void
-	 */
-	public function GET () {
-		return $this->Vrfs_controller->GET ();
-	}
-
-
-	/**
-	 * Updates existing subnet
-	 *
-	 * @access public
-	 * @return void
-	 */
-	public function PATCH () {
-		return $this->Vrfs_controller->PATCH ();
-	}
-
-
-	/**
-	 * Deletes existing subnet along with and addresses
-	 *
-	 * @access public
-	 * @return void
-	 */
-	public function DELETE () {
-		return $this->Vrfs_controller->DELETE ();
-	}
+class Vrf_controller extends Vrfs_controller {
 }

--- a/api/controllers/Vrfs.php
+++ b/api/controllers/Vrfs.php
@@ -8,64 +8,6 @@
 
 class Vrfs_controller extends Common_api_functions {
 
-
-	/**
-	 * _params [provided
-	 *
-	 * @var mixed
-	 * @access public
-	 */
-	public $_params;
-
-	/**
-	 * Custom address fields
-	 *
-	 * @var mixed
-	 * @access public
-	 */
-	public $custom_fields;
-
-	/**
-	 * Database object
-	 *
-	 * @var mixed
-	 * @access protected
-	 */
-	protected $Database;
-
-	/**
-	 * Master Sections object
-	 *
-	 * @var mixed
-	 * @access protected
-	 */
-	protected $Sections;
-
-	/**
-	 * Master Subnets object
-	 *
-	 * @var mixed
-	 * @access protected
-	 */
-	protected $Subnets;
-
-	/**
-	 * Master Tools object
-	 *
-	 * @var mixed
-	 * @access protected
-	 */
-	protected $Tools;
-
-	/**
-	 * Master  Admin object
-	 *
-	 * @var mixed
-	 * @access protected
-	 */
-	protected $Admin;
-
-
 	/**
 	 * __construct function
 	 *
@@ -187,20 +129,6 @@ class Vrfs_controller extends Common_api_functions {
 			if($result===false)						{ $this->Response->throw_exception(404, "VRF not found"); }
 			else									{ return array("code"=>200, "data"=>$this->prepare_result ($result, null, true, true)); }
 		}
-	}
-
-
-
-
-
-	/**
-	 * HEAD, no response
-	 *
-	 * @access public
-	 * @return void
-	 */
-	public function HEAD () {
-		return $this->GET ();
 	}
 
 


### PR DESCRIPTION
- Avoid redeclaring class variables inherited from Common_api_functions.
- Move common variables to Common_api_functions.
- Add default OPTIONS, GET, POST, PATCH & DELETE methods returning 501.
- Alias HEAD->GET and PUT->PATCH.
- Use class inheritance for Vlan/Vlans Vrf/Vrfs aliases.

Closes #3419