### PR TITLE
Add a link to Google Maps, satellite view next to the GPS coordinates…

### DIFF
--- a/app/tools/locations/single-location.php
+++ b/app/tools/locations/single-location.php
@@ -69,7 +69,7 @@ else {
             	print "<tr>";
             	print "	<th>"._('Coordinates')."</th>";
             	print "	<td>";
-            	print strlen($location->lat)>0 && strlen($location->long)>0 ? "<span class='text-muted'>".escape_input($location->lat)." / ".escape_input($location->long)."</span>" : "/";
+            	print strlen($location->lat)>0 && strlen($location->long)>0 ? "<span class='text-muted'>".escape_input($location->lat)." / ".escape_input($location->long)."</span> <a href='https://www.google.com/maps/@?api=1&map_action=map&center=".escape_input($location->lat)."%2C".escape_input($location->long). "&zoom=20&basemap=satellite' target='_blank'><i class='fa fa-gray fa-google' rel='tooltip' title='"._("Google Maps Satellite View")."'></i></a>" : "/";
             	print "</td>";
             	print "</tr>";
 


### PR DESCRIPTION
…… (#3426)

* Add a link to Google Maps, satellite view next to the GPS coordinates on the location details page. Open Street maps is great for not needing an API key, but for locations of things like cell towers, fiber nodes, or other equipment that is in odd locations, a satellite view is great.

* Use font-awesome icon for Google Maps Link.

* i18n text.