### PR TITLE
Bugfix: SAML return to same page when session expires.

### DIFF
--- a/app/login/index.php
+++ b/app/login/index.php
@@ -8,7 +8,7 @@ if( !empty($_SERVER['PHP_AUTH_USER']) ) {
     // try to authenticate
 	$User->authenticate ($_SERVER['PHP_AUTH_USER'], '');
 	// Redirect user where he came from, if unknown go to dashboard.
-	if( !empty($_COOKIE['phpipamredirect']) )   { header("Location: ".escape_input($_COOKIE['phpipamredirect'])); }
+	if( !empty($_COOKIE['phpipamredirect']) )   { header("Location: ".safeurlencode($_COOKIE['phpipamredirect'])); }
 	else                                        { header("Location: ".create_link("dashboard")); }
 	exit();
 }

--- a/app/saml2/index.php
+++ b/app/saml2/index.php
@@ -115,7 +115,7 @@ else{
 	$User->authenticate ($username, '', true);
 
 	// Redirect user where he came from, if unknown go to dashboard.
-	if( !empty($_COOKIE['phpipamredirect']) )   { header("Location: ".escape_input($_COOKIE['phpipamredirect'])); }
+	if( !empty($_COOKIE['phpipamredirect']) )   { header("Location: ".safeurlencode($_COOKIE['phpipamredirect'])); }
 	else                                        { header("Location: ".create_link("dashboard")); }
 
 }

--- a/config.dist.php
+++ b/config.dist.php
@@ -98,8 +98,8 @@ $phpsessname = "phpipam";
 /**
  * Cookie SameSite settings ("None", "Lax"=Default, "Strict")
  * - "Strict" increases security
- * - "Lax" required for SAML2
- * - "None" requires HTTPS
+ * - "Lax" required for SAML2, some SAML topologies may require "None".
+ * - "None" requires HTTPS (implies "Secure;")
  */
 $cookie_samesite = "Lax";
 

--- a/config.docker.php
+++ b/config.docker.php
@@ -67,6 +67,14 @@ $proxy_use_auth = file_env('PROXY_USE_AUTH', $proxy_use_auth);
 $debugging = filter_var(file_env('IPAM_DEBUG', $debugging), FILTER_VALIDATE_BOOLEAN);
 
 /**
+ * Cookie SameSite settings ("None", "Lax"=Default, "Strict")
+ * - "Strict" increases security
+ * - "Lax" required for SAML2, some SAML topologies may require "None".
+ * - "None" requires HTTPS (implies "Secure;")
+ */
+$cookie_samesite = file_env('COOKIE_SAMESITE', $cookie_samesite);
+
+/**
  * Session storage - files or database
  *
  * @var string

--- a/functions/classes/class.User.php
+++ b/functions/classes/class.User.php
@@ -494,7 +494,7 @@ class User extends Common_functions {
             return;
         }
 
-        setcookie_samesite("phpipamredirect", preg_replace('/^\/+/', '/', $uri), 10, true);
+        setcookie_samesite("phpipamredirect", preg_replace('/^\/+/', '/', $uri), 120, true);
     }
 
     /**

--- a/functions/global_functions.php
+++ b/functions/global_functions.php
@@ -112,7 +112,23 @@ function create_link ($l0 = null, $l1 = null, $l2 = null, $l3 = null, $l4 = null
  * @return string
  */
 function escape_input($data) {
-	return (!isset($data) || strlen($data)==0) ? '' : htmlentities($data, ENT_QUOTES);
+	if (!isset($data) || !is_string($data))
+		return '';
+	$safe_data = htmlentities($data, ENT_QUOTES);
+	return is_string($safe_data) ? $safe_data : '';
+}
+
+/**
+ * Sanitise URL inputs/outputs
+ *
+ * @param   mixed  $url
+ * @return  string
+ */
+function safeurlencode($url) {
+	if (!isset($url) || !is_string($url))
+		return '';
+	$safe_url = rawurlencode(filter_var(trim($url), FILTER_SANITIZE_URL));
+	return is_string($safe_url) ? $safe_url : '';
 }
 
 /**
@@ -223,9 +239,10 @@ function setcookie_samesite($name, $value, $lifetime, $httponly=false) {
 	date_default_timezone_set($tz);
 
 	$samesite = Config::ValueOf("cookie_samesite", "Lax");
-	if (!in_array($samesite, ["None", "Lax", "Secure"])) $samesite="Lax";
+	if (!in_array($samesite, ["None", "Lax", "Strict"])) $samesite="Lax";
 
-	$httponly = ($httponly===true) ? ' HttpOnly;' : '';
+	$secure = ($samesite=="None") ? " Secure;" : '';
+	$httponly = $httponly ? ' HttpOnly;' : '';
 
-	header("Set-Cookie: $name=$value; expires=$expire_date; Max-Age=$lifetime; path=/; SameSite=$samesite;".$httponly);
+	header("Set-Cookie: $name=$value; expires=$expire_date; Max-Age=$lifetime; path=/; SameSite=$samesite;".$secure.$httponly);
 }


### PR DESCRIPTION
- Fix config.php $cookie_samesite = "Strict"; handling.

- Use rawurlencode() when setting login redirect headers.

- Cookie SameSite="None" attribute mandates also setting Secure attribute. https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite HTTPS is mandatory when using Cookie SameSite="None", required in some SAML topologies.

- Increase phpipamredirect cookie lifetime to 2 mins. 2FA authentication may take >10s.

- Add docker COOKIE_SAMESITE env configuration option.

Closes #3429