### PR TITLE
SAML JIT Provisioning (#3389)

### DIFF
--- a/app/admin/authentication-methods/edit-SAML2.php
+++ b/app/admin/authentication-methods/edit-SAML2.php
@@ -84,6 +84,15 @@ $(document).ready(function() {
 
 	<!-- Advanced Settings -->
 	<tr>
+		<td><?php print _('Enable JIT'); ?></td>
+		<td>
+			<input type="checkbox" class="input-switch" value="1" name="jit" <?php if(@$method_settings->params->jit == 1) print 'checked'; ?>  <?php print $is_disabled; ?> >
+		</td>
+		<td class="info2">
+			<?php print _('Provision new users automatically'); ?><br>
+		</td>
+	</tr>
+	<tr>
 		<td><?php print _('Use advanced settings'); ?></td>
 		<td>
 			<input type="checkbox" class="input-switch" value="1" name="advanced" <?php if(@$method_settings->params->advanced == 1) print 'checked'; ?>  <?php print $is_disabled; ?> >

--- a/app/admin/authentication-methods/edit-result.php
+++ b/app/admin/authentication-methods/edit-result.php
@@ -44,14 +44,28 @@ $values = array(
 				"type"        =>$_POST['type'],
 				"description" =>@$_POST['description'],
 				);
+
+# Validate input
+if (isset($_POST['type']) && $_POST['type']=="SAML2") {
+	# The JIT & SAML mapped user options are mutually exclusive.
+	if (filter_var($_POST['jit'], FILTER_VALIDATE_BOOLEAN) && !empty($_POST['MappedUser'])) {
+		$Result->show("danger",  _("The JIT and mapped user options are mutually exclusive"), true);
+	}
+
+	# Validate Prettify links is enabled for strict mode.
+	if (filter_var($_POST['strict'], FILTER_VALIDATE_BOOLEAN) && !filter_var($User->settings->prettyLinks, FILTER_VALIDATE_BOOLEAN)) {
+		$Result->show("danger",  _("Strict mode requires global setting \"Prettify links\"=yes"), true);
+	}
+
+	# Verify that the private certificate and key are provided if Signing Authn Requests is set
+	if($action!="delete" && filter_var(['spsignauthn'], FILTER_VALIDATE_BOOLEAN) && (empty($_POST['spx509cert']) || empty($_POST['spx509key']))) {
+		$Result->show("danger",  _("SP (Client) certificate and key are required to sign Authn requests"), true);
+	}
+}
+
 # remove processed params
 unset($_POST['id'], $_POST['type'], $_POST['description'], $_POST['action']);
 $values["params"]=json_encode($_POST);
-
-#Verify that the private certificate and key are provided if Signing Authn Requests is set
-if($action!="delete" && @$_POST['spsignauthn']=="1" && (empty($_POST['spx509cert']) || empty($_POST['spx509key']))) {
-	$Result->show("danger",  _("SP (Client) certificate and key are required to sign Authn requests"), true);
-}
 
 $secure_keys=[
 	'adminUsername',

--- a/app/saml2/index.php
+++ b/app/saml2/index.php
@@ -107,12 +107,117 @@ else{
         // Extract username from attribute
         $attr = $auth->getAttribute($params->UserNameAttr);
         $username = is_array($attr) ? $attr[0] : '';
+        $username_source = "getAttribute(".escape_input($params->UserNameAttr).")";
 	} else {
         // Extract username from NameId
 		$username = $auth->getNameId();
+        $username_source = "getNameId()";
 	}
 
-	$User->authenticate ($username, '', true);
+    // Validate username
+    if (!isset($username) || !is_string($username) || strlen($username)==0) {
+        $Result->show("danger", _("Could not extract valid username from SAML response")." : ".$username_source, true);
+    }
+
+    // Attempt JIT if enabled
+    if(filter_var($params->jit, FILTER_VALIDATE_BOOLEAN)) {
+
+        //
+        // Auto provision users via SAML attributes
+        //
+        // - "display_name", (String), MANDATORY
+        //   Users real name / full name.
+        //   Can not be blank.
+        //
+        // - "email", (String), MANDATORY
+        //   Users email address.
+        //   Can not be blank. Must pass filter_var($email, FILTER_VALIDATE_EMAIL).
+        //
+        // - "is_admin", (Boolean), OPTIONAL, default: 0
+        //   User role, "Administrator" or "Normal User".
+        //
+        // - "groups", (String), OPTIONAL (Admins have admin level access to all groups), default: ""
+        //   Comma separated list of group membership.
+        //   e.g "groups"="Operators,Guests"
+        //
+        // - "modules", (String), OPTIONAL (Admins have admin level access to all modules), default: ""
+        //   Comma separated list of modules with permission level, 0=None, 1=Read, 2=Read/Write, 3=Admin
+        //   "*" can be used to wildcard match all modules.
+        //   e.g The following will assign admin permissions to the vlan module and read permissions to everything else.
+        //       "modules" = "*:1,vlan:3"
+
+        if (empty($auth->getAttribute("display_name")[0])) {
+            $Result->show("danger", _("Mandatory SAML JIT attribute missing")." : display_name (string)", true);
+        }
+        elseif (!filter_var($auth->getAttribute("email")[0], FILTER_VALIDATE_EMAIL)) {
+            $Result->show("danger", _("Mandatory SAML JIT attribute missing")." : email (string)", true);
+        }
+
+        $values = [];
+
+        $existing_user = $User->fetch_object("users", "username", $username);
+
+        if (is_object($existing_user)) {
+            // User exists in DB. Check this is a SAML account.
+
+            if ($existing_user->authMethod != $dbobj->id) {
+                $Result->show("danger", _("Requested SAML user is not configured for SAML authentication")." : ".escape_input($username), true);
+            }
+
+            $action = "edit";
+            $values["id"] = $existing_user->id;
+        }
+        else {
+            // User does not exist in DB. Auto-provision user.
+
+            $action = "add";
+            $values["username"] = $username;
+            $values["authMethod"] = $dbobj->id;
+            $values["lang"] = $User->settings->defaultLang;
+        }
+
+        $values["real_name"] = $auth->getAttribute("display_name")[0];
+        $values["email"] = $auth->getAttribute("email")[0];
+        $values["role"] = filter_var($auth->getAttribute("is_admin")[0], FILTER_VALIDATE_BOOLEAN) ? "Administrator" : "User";
+
+        // Parse groups
+        $saml_groups = array_map('trim', explode(',', $auth->getAttribute("groups")[0])) ? : [];
+
+        $ug = [];
+        foreach ($Tools->fetch_all_objects("userGroups", "g_id") as $g) {
+            if (in_array($g->g_name, $saml_groups)) {
+                $ug[$g->g_id] = $g->g_id;
+            }
+        }
+        $values["groups"]  = json_encode($ug);
+
+        //parse modules
+        $saml_modules = [];
+        foreach(explode(',', $auth->getAttribute("modules")[0]) as $entry){
+            if (strpos($entry, ":")!==false) {
+                list($module_name, $module_perm) = array_map('trim', explode(':', $entry)) ? : ['', 0];
+                $saml_modules[$module_name] = filter_var($module_perm, FILTER_VALIDATE_INT, ["options"=>["default"=>0, "min_range"=>0, "max_range"=>3]]);
+            }
+        }
+
+        $um = [];
+        foreach($User->get_modules_with_permissions() as $module) {
+            // Allow "*" wildcard
+            if (array_key_exists('*', $saml_modules)) {
+                $um[$module] = $saml_modules['*'];
+            }
+            if (array_key_exists($module, $saml_modules)) {
+                $um[$module] = $saml_modules[$module];
+            }
+        }
+        $values["module_permissions"] = json_encode($um);
+
+        // Construct admin object for helper functions
+        $Admin = new Admin($Database, false);
+        if (!$Admin->object_modify("users", $action, "id", $values)) { $Result->show("danger", _("Failed to create/update SAML JIT user")." : ".escape_input($username), true); }
+    }
+
+    $User->authenticate ($username, '', true);
 
 	// Redirect user where he came from, if unknown go to dashboard.
 	if( !empty($_COOKIE['phpipamredirect']) )   { header("Location: ".safeurlencode($_COOKIE['phpipamredirect'])); }

--- a/misc/CHANGELOG
+++ b/misc/CHANGELOG
@@ -23,6 +23,7 @@
         + php-saml protocol debugging;
         + Support for signed assertions;
         + SAML usernames can be extracted from assertion attributes (#2948);
+        + JIT auto-provisioning of accounts (#3389);
     + Selectable mask for number of subnets/hosts in subnet masks;
     + Switch from Google Maps to OpenStreeMap and Nominatim;
 


### PR DESCRIPTION
Auto provision users via SAML attributes

   - "display_name", (String), MANDATORY Users real name / full name. Can not be blank.

   - "email", (String), MANDATORY Users email address. Can not be blank. Must pass filter_var($email, FILTER_VALIDATE_EMAIL).

   - "is_admin", (Boolean), OPTIONAL, default: 0 User role, "Administrator" or "Normal User".

   - "groups", (String), OPTIONAL (Admins have admin level access to all groups), default: "" Comma separated list of group membership. e.g "groups"="Operators,Guests"

   - "modules", (String), OPTIONAL (Admins have admin level access to all modules), default: "" Comma separated list of modules with permission level, 0=None, 1=Read, 2=Read/Write, 3=Admin "*" can be used to wildcard match all modules. e.g The following will assign admin permissions to the vlan module and read permissions to everything else. "modules" = "*:1,vlan:3"